### PR TITLE
TS3 Server version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ services:
     #  # You can set any of the build arguments
     #  args:
     #    TS3SERVER_VERSION: 3.3.0
-    #    TS3SERVER_SHA384: <sha384 sum of the version you want to build for>
+    #    TS3SERVER_SHA256: <sha256 sum of the version you want to build for>
+    #    TS3SERVER_SHA384: <sha384 sum of the version you want to build for - provided for backwards compatibility>
     #    TS3SERVER_URL: <direct URL to a mirror of the TeamSpeak3 version>
     #    # ...
 


### PR DESCRIPTION
Hey,

this pull requests changes 2 things:
- updates ts3server to 3.4.0
- adds compatibility for sha256 check from ts website

The sha256 check has been implemented in a way that if you provide a custom sha384 the build will not break as the sha384 is used primarily.

Advantage is that you can use the official sha256 hashes provided by teamspeak itself.