### PR TITLE
Update to ts3server 3.6.1 and Alpine 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.6.0"
+ARG TS3SERVER_VERSION="3.6.1"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="amd64"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="5a0ed8229c0c8f071b85b1ac02a7176562b6386dae66babfaa553d5da26386be"
+ARG TS3SERVER_SHA256="07c9680064ae64851269fbdbce159006e547b30bb5fa16b355230ddfdc59f671"
 ARG TS3SERVER_SHA384=""
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 # Add "app" user
 RUN mkdir -p /tmp/empty \
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.6.0"
+ARG TS3SERVER_VERSION="3.6.1"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="alpine"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="9ebc46917792ca4b7e7cdaf3eeff11a5f55347a018c76b83da0d9bb2b56abd5b"
+ARG TS3SERVER_SHA256="3f98dbb92c562f101aa9b3b78e22452c5e57290f72c98cc074a332e2e3963a1e"
 ARG TS3SERVER_SHA384=""
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"


### PR DESCRIPTION
```
=== Server Release 3.6.1 30 january 2019
Fixed: Adding a client channel permission will set the correct values again.
Fixed: Fixed server crash related to adding a lot of server queries.
```