### PR TITLE
Update to ts3server 3.7.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.6.1"
+ARG TS3SERVER_VERSION="3.7.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="amd64"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="07c9680064ae64851269fbdbce159006e547b30bb5fa16b355230ddfdc59f671"
+ARG TS3SERVER_SHA256="6abcbaf3697c28220375cf681e46fe379b4d82102f1ec6d201363c6ee73f205d"
 ARG TS3SERVER_SHA384=""
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.6.1"
+ARG TS3SERVER_VERSION="3.7.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="alpine"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="3f98dbb92c562f101aa9b3b78e22452c5e57290f72c98cc074a332e2e3963a1e"
+ARG TS3SERVER_SHA256="ac195047f5c8d626c20197f0c01a362ef7cc48d8cf6537acb5c85dfbaf523382"
 ARG TS3SERVER_SHA384=""
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"


### PR DESCRIPTION
Changelog:

```
=== Server Release 3.7.0 19 March 2019
Important: Future releases of the Linux server will require glibc 2.17 or newer.
           Any older version will not be supported anymore.

Added: New experimental features for the upcoming TeamSpeak 5 Client.
Added: Server now logs when deleting someone else's avatar.
Added: The IP address of a connecting ServerQuery client is now logged.
Added: The query commands `clientlist -ip` and `clientinfo` show the IP address
       of connected query clients.
Added: Restricted the amount of possible ServerQuery connections to five per IP.
       Whitelisted IPs ignore this limit, and the limit can be changed using
       `instanceedit serverinstance_serverquery_max_connections_per_ip=<limit>`
       in the ServerQuery.

Changed: Updated default license to be valid until the 31st of January 2020.
Changed: ServerQuery clients will no longer have their IP address added to the
         default nickname.
Changed: The query command `privilegekeyadd` will no longer create privilege
         keys for query groups.

Fixed: Improved speed of clientdblist.
Fixed: Unicode support in interactive query ssh sessions.
Fixed: IP-Location database is up to date again.
Fixed: Server crash when a client sent a malformed login.
Fixed: Broken ban pattern matches on older Linux platforms.

Removed: Legacy codecs (Speex, CELT) can no longer be selected when creating
         or editing channels. Support for these codecs will be removed with
         future server releases.
Removed: Permission 'b_client_issue_client_query_command' was removed, because
         it was not being used for anything.
```