### PR TITLE
Update to ts3server 3.7.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.7.0"
+ARG TS3SERVER_VERSION="3.7.1"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="amd64"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="6abcbaf3697c28220375cf681e46fe379b4d82102f1ec6d201363c6ee73f205d"
+ARG TS3SERVER_SHA256="6787d4c9fd6f72d1386872a61f38f932a8ee745046b1497168286ffd0311c0f0"
 ARG TS3SERVER_SHA384=""
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.7.0"
+ARG TS3SERVER_VERSION="3.7.1"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="alpine"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="ac195047f5c8d626c20197f0c01a362ef7cc48d8cf6537acb5c85dfbaf523382"
+ARG TS3SERVER_SHA256="c82eebbe5dca9f33c8e52b0526fb92613f975c73463687e1561eefb79c0e5a69"
 ARG TS3SERVER_SHA384=""
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"


### PR DESCRIPTION
```
=== Server Release 3.7.1 28 March 2019
Changed: Improved modification prevention of unique server identifier

Fixed: Regression of permission bypass checks.
Fixed: A rare crash when using the ServerQuery.
```