### PR TITLE
Update to ts3server 3.8.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.7.1"
+ARG TS3SERVER_VERSION="3.8.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="amd64"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="6787d4c9fd6f72d1386872a61f38f932a8ee745046b1497168286ffd0311c0f0"
+ARG TS3SERVER_SHA256="6122ec5949cf53d91b7b8f76c5e7ea9921fd1ec07dce3cf715d8587e31c6f5af"
 ARG TS3SERVER_SHA384=""
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.7.1"
+ARG TS3SERVER_VERSION="3.8.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="alpine"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="c82eebbe5dca9f33c8e52b0526fb92613f975c73463687e1561eefb79c0e5a69"
+ARG TS3SERVER_SHA256="4782b19514abecdaefe498fced970bf9ae74f7d9699c5b60960f422add8dbb50"
 ARG TS3SERVER_SHA384=""
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"


### PR DESCRIPTION
```
=== Server Release 3.8.0 28 May 2019

Important: This release requires GNU C library (glibc) 2.17 or later on Linux. If you need to
           check which version of glibc is installed on your system, you can use `ldd --version`,
           which usually comes with any glibc installation.
Important: Client badge information is now signed to prevent using fake data. Badges in the old
           format will not be visible on this server.
           TeamSpeak Client version 3.3.0 with support for signed badges will be available soon.

Added: The query command `banlist` now supports optional pagination parameters.
       Please refer to the ServerQuery documentation for details.
Added: Temporary passwords are now stored in the database and will be loaded on start.
Added: New command line parameters 'daemon' and 'pid_file'. This makes it possible
       to start the server as a daemon.
Added: Channel properties and permissions to support channel banners.
       This feature requires TeamSpeak Client version 5.

Changed: The startscript restart parameter now allows to use more than one parameter.
Changed: New server logs are no longer created with a BOM.
Changed: Server / channel icons will not display as negative values anymore in ServerQuery.
Changed: ServerQuery commands `clientlist -ip` and `clientinfo` won't display brackets around IPv6
         addresses of clients anymore.
Changed: Max size of text messages has been increased to 8 KiB for improved usability in upcoming
         TeamSpeak Client releases.

Fixed: Reduced packet loss on systems under high load.
Fixed: In some rare case the server did crash when shutting down a virtual server.
Fixed: The startscript restart parameter could not be used when ran outside the server directory.
Fixed: Server did report the ability to create channels to the weblist in cases where a client
       could not create any channel.
```