### PR TITLE
Update to ts3server 3.9.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.8.0"
+ARG TS3SERVER_VERSION="3.9.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="amd64"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="6122ec5949cf53d91b7b8f76c5e7ea9921fd1ec07dce3cf715d8587e31c6f5af"
+ARG TS3SERVER_SHA256="4b945e9216b7627b015b47b6233f3a55c74e4d74701ae0aecf88f811fa098e99"
 ARG TS3SERVER_SHA384=""
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.8.0"
+ARG TS3SERVER_VERSION="3.9.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="alpine"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="4782b19514abecdaefe498fced970bf9ae74f7d9699c5b60960f422add8dbb50"
+ARG TS3SERVER_SHA256="cca4071addd9e68b53564c5c0ed361a3f798693350a64de122feadf1c7b3e8bb"
 ARG TS3SERVER_SHA384=""
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"


### PR DESCRIPTION
```
## Server Release 3.9.0 24 June 2019

### Added
- Support for new license types (Gamer, Commercial, Sponsorship).
- `clientaddservergroup` and `clientdelservergroup` allowing to add and remove one
  or more server groups to a client.

### Changed
- `servergroupaddclient` and `servergroupdelclient` allow to add and remove one
  or more clients to a server group.
- `quit` can be used while being flood banned.
- `channeledit`, `channelpermlist` and `custominfo` return 
  more appropriate error codes.
- `servertemppasswordadd` does not allow a zero duration.
- Parsing of boolean parameters has been made more restrictive.
- Plugin command notifications contain invoker data.

### Fixed
- QueryAdmin-Password and ServerAdmin-Token are printed again, when starting the
  TeamSpeak 3 Server using the startscript or with the daemon parameter.
- A crash related to 'set_option: Bad file descriptor' has been fixed.
- Temporary passwords are being checked for clients with the
  ignore server password priviledge. 
- A bug where some ServerQuery notifications were sent twice after using
  `servernotify`
- `serverlist -short -uid` works as expected now.
- `clientlist -badges` shows all client badges again.
- Startscript checks if instance is already running.
- Server did not start any longer on some Linux systems 
  Thank you 'Ragyal'.
```