### PR TITLE
Update to ts3server 3.11.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.10.2"
+ARG TS3SERVER_VERSION="3.11.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="amd64"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="d4262f0d51e682c0c645b36c196ad32dae99a1345420cfad00d52f2af109870d"
+ARG TS3SERVER_SHA256="18c63ed4a3dc7422e677cbbc335e8cbcbb27acd569e9f2e1ce86e09642c81aa2"
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"
 

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.10.2"
+ARG TS3SERVER_VERSION="3.11.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="alpine"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="ba5b00c95266831a2dc40e778396a3b553e70d778883f025aa16befbca56c908"
+ARG TS3SERVER_SHA256="f93e96b556e11fc7b520416b6a22cde902ae12ef14a7f99b0107cde97ce48fc6"
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"
 


### PR DESCRIPTION
```
## Server Release 3.11.0 15 January 2020

### Important
-  Channel with deprecated codecs (Speex/CELT) are being updated to use Opus instead.

### Added
- The query command `privilegekeylist` also returns the `token_customset` now.
- The query command `channellist` has a new option `-banners`

### Changed
- Because of degraded performance on larger servers, the new hint system has been disabled per default.
- Made further improvements to timeout and latency handling for larger servers.

### Fixed
- Adding or removing user in ServerQuery groups may have returned invalid error codes.
- Changing `serverinstance_guest_serverquery_group` properly ensures only
  ServerQuery groups can be assigned.
```