### PR TITLE
Update to ts3server 3.12.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.11.0"
+ARG TS3SERVER_VERSION="3.12.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="amd64"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="18c63ed4a3dc7422e677cbbc335e8cbcbb27acd569e9f2e1ce86e09642c81aa2"
+ARG TS3SERVER_SHA256="a8a65388bb1d32260d3568e7bfb7da264f58a1256799e30309589856e4b36b51"
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"
 
@@ -77,4 +77,4 @@ USER app
 # Can't use $TS3SERVER_INSTALL_DIR here because ENTRYPOINT does not accept variables
 ENTRYPOINT [ "ts3server", "dbsqlpath=/opt/ts3server/sql/", "serverquerydocs_path=/opt/ts3server/serverquerydocs/", "query_ip_whitelist=/data/query_ip_whitelist.txt", "query_ip_blacklist=/data/query_ip_blacklist.txt", "createinifile=1" ]
 
-EXPOSE 9987/udp 10011 10022 30033 41144
+EXPOSE 9987/udp 10011 10022 10080 10443 30033 41144

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -10,12 +10,12 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.11.0"
+ARG TS3SERVER_VERSION="3.12.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="alpine"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
 #ARG TS3SERVER_URL="http://dl.4players.de/ts/releases/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="f93e96b556e11fc7b520416b6a22cde902ae12ef14a7f99b0107cde97ce48fc6"
+ARG TS3SERVER_SHA256="6f414b427f43aef5a0ab95e0b996b7ba9620ad7b0017fff8c9bdb2855beef066"
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"
 
@@ -72,4 +72,4 @@ USER app
 # Can't use $TS3SERVER_INSTALL_DIR here because ENTRYPOINT does not accept variables
 ENTRYPOINT [ "ts3server", "dbsqlpath=/opt/ts3server/sql/", "serverquerydocs_path=/opt/ts3server/serverquerydocs/", "query_ip_whitelist=/data/query_ip_whitelist.txt", "query_ip_blacklist=/data/query_ip_blacklist.txt", "createinifile=1" ]
 
-EXPOSE 9987/udp 10011 10022 30033 41144
+EXPOSE 9987/udp 10011 10022 10080 10443 30033 41144


### PR DESCRIPTION
```
## Server Release 3.12.0 18 March 2020

### Important
- New feature WebQuery that allows user to access to query system using http(s) and json. 

### Added
- New query commands `apikeyadd`, `apikeydel` and `apikeylist`
  for managing API keys used in WebQuery
- New permissions `b_virtualserver_apikey_add` and `b_virtualserver_apikey_manage` that restrict who can create/delete/list API keys.
- New possible value for parameter `query_protocols` named `http` and `https` that enables WebQuery
- New parameters `query_http_ip` and `query_http_port` that define where WebQuery can be reached, default is all interfaces on port `10080`
- New parameters `query_https_ip` and `query_https_port` that define where WebQuery can be reached, default is all interfaces on port `10443`

### Changed
- macOS 10.14 Mojave is required from now on
- Raised version of snapshots and added support for API keys 

### Fixed
- Whisper bug that resulted in users not being able to receive whispers
- Removed requirement of having a cpu with POPCNT for 32bit version, and added an appropriate error message for the 64bit version
- Deploying snapshots will import client and channel permissions, again
```