### PR TITLE
Update to ts3server 3.13.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.12.1"
+ARG TS3SERVER_VERSION="3.13.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="amd64"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="cfbffba30a570f0ba33a74ce5e5dbda54ce564d917a27183cdcaf82cc2b4abb7"
+ARG TS3SERVER_SHA256="64cef96f0254645a231aab3443e4e9216862733fcad52793dba1e170e8fcd7e9"
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"
 
@@ -74,6 +74,6 @@ RUN \
 
 USER app
 # Can't use $TS3SERVER_INSTALL_DIR here because ENTRYPOINT does not accept variables
-ENTRYPOINT [ "ts3server", "dbsqlpath=/opt/ts3server/sql/", "serverquerydocs_path=/opt/ts3server/serverquerydocs/", "query_ip_whitelist=/data/query_ip_whitelist.txt", "query_ip_blacklist=/data/query_ip_blacklist.txt", "createinifile=1" ]
+ENTRYPOINT [ "ts3server", "dbsqlpath=/opt/ts3server/sql/", "serverquerydocs_path=/opt/ts3server/serverquerydocs/", "query_ip_allowlist=/data/query_ip_allowlist.txt", "query_ip_denylist=/data/query_ip_denylist.txt", "createinifile=1" ]
 
 EXPOSE 9987/udp 10011 10022 10080 10443 30033 41144

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 # Add "app" user
 RUN mkdir -p /tmp/empty \
@@ -10,11 +10,11 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.12.1"
+ARG TS3SERVER_VERSION="3.13.0"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="alpine"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="b1d5876854992bf9f5d7bc6b12be71bee9bfe90185b78c74bc50ed5a02f360a2"
+ARG TS3SERVER_SHA256="8a951c07ded91d412d5d2bbcbc6cc210cdd6c52bad0ba5a9bae69d3569ea6ccb"
 ARG TS3SERVER_TAR_ARGS="-j"
 ARG TS3SERVER_INSTALL_DIR="/opt/ts3server"
 
@@ -69,6 +69,6 @@ RUN \
 
 USER app
 # Can't use $TS3SERVER_INSTALL_DIR here because ENTRYPOINT does not accept variables
-ENTRYPOINT [ "ts3server", "dbsqlpath=/opt/ts3server/sql/", "serverquerydocs_path=/opt/ts3server/serverquerydocs/", "query_ip_whitelist=/data/query_ip_whitelist.txt", "query_ip_blacklist=/data/query_ip_blacklist.txt", "createinifile=1" ]
+ENTRYPOINT [ "ts3server", "dbsqlpath=/opt/ts3server/sql/", "serverquerydocs_path=/opt/ts3server/serverquerydocs/", "query_ip_allowlist=/data/query_ip_allowlist.txt", "query_ip_denylist=/data/query_ip_denylist.txt", "createinifile=1" ]
 
 EXPOSE 9987/udp 10011 10022 10080 10443 30033 41144


### PR DESCRIPTION
```
## Server Release 3.13.0 9 November 2020

### Important
- Support for 32-bit builds of FreeBSD has been dropped. 64-bit FreeBSD is still supported.
- The server_quickstart.txt file is now in Markdown format as server_quickstart.md. It has also been significantly updated.

### Fixed
- Fixed slow startup after an SQLite schema migration
- Better handling of invalid base64 snapshots
- Fixed an issue with negative whisper power permission checks
- Fixed possible memory leak under certain obscure conditions
- Fixed query login groups being improperly cached in certain cases
- Invalid password attempts should respect SERVERINSTANCE_SERVERQUERY_BAN_TIME

### Added
- New support for PostgreSQL databases. Please read server_quickstart for more information.
- New support for MMDB style GeoIP databases (again, see server_quickstart!)
- Webquery supports access by server port : /byport/9987/clientinfo will send the command to the virtualserver at port 9987.
- Added warning for cases of UDP socket failure
- banclient can now accept multiple clientids
- banclient, clientmove and clientkick accept the -continueonerror parameter to ignore errors
- New optional parameter for clientlist '-location'
- Advanced users: Added a new command line argument `logquerytiminginterval` for diagnostic logging of ServerQuery timing.
- Advanced users: Added a new command line argument `querypoolsize` to allow you to specify the number of threads in the ServerQuery pool.

### Changed
- Note: query_ip_whitelist has been renamed to query_ip_allowlist, and query_ip_blacklist is now query_ip_denylist.
- Note: the old whitelist/blacklist names are still accepted.
- Webquery errors will return a HTTP 4xx series status code.
- Improved database performance for some query commands (notably serverlist)
- permget returns 'invalid perm id' error if permid is 0, or convert error if negative
- instanceedit no longer allows query groups for server template groups
- serveredit should correctly update client idle time
- Better validation of tokencustomsets when creating privilege keys
- Various permlist commands now include the relevant id (client, etc) in the output for your convenience
- MariaDB plugin should be a little more tolerant of broken connections
- We now print a warning if you specify an unknown command line option