### PR TITLE
Update to ts3server 3.13.5.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,11 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.13.3"
+ARG TS3SERVER_VERSION="3.13.5"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="amd64"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="f9bf52d1e9109971792b0bd57261c80e9a7489944ed96d65b3c798843ce3514c"
+ARG TS3SERVER_SHA256="dad497fc44f6959b22d26541dca9db9c15cc49346c9de19403cc3a999e939a56"
 ARG TS3SERVER_TAR_ARGS="-j"
 ENV TS3SERVER_INSTALL_DIR="/opt/ts3server"
 

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -17,11 +17,11 @@ RUN mkdir -p /tmp/empty \
 RUN mkdir -p /data && chown app:app /data
 WORKDIR /data
 
-ARG TS3SERVER_VERSION="3.13.3"
+ARG TS3SERVER_VERSION="3.13.5"
 # Possible values are alpine, amd64, x86
 ARG TS3SERVER_VARIANT="alpine"
 ARG TS3SERVER_URL="https://files.teamspeak-services.com/releases/server/${TS3SERVER_VERSION}/teamspeak3-server_linux_${TS3SERVER_VARIANT}-${TS3SERVER_VERSION}.tar.bz2"
-ARG TS3SERVER_SHA256="b4134aeba964782e10c22dcb96b6de4c96e558965e9d5ed9b0db47e648ad1498"
+ARG TS3SERVER_SHA256="db70478d8b2d6358c0005504f1673e490ec0220b7ab93bdb418f0b051f4940aa"
 ARG TS3SERVER_TAR_ARGS="-j"
 ENV TS3SERVER_INSTALL_DIR="/opt/ts3server"
 


### PR DESCRIPTION
```
Server Release 3.13.5 18 May 2021
Fixed
  Multiple ways to crash server on virtual server shutdown.
   Performance increase when many clients log in at the same time.
   Fix crash in HTTP query.
   Fix crash on Windows during startup.
   Fix HTTP api key creation issue when using postgresql as DB.

```